### PR TITLE
Cublas handle

### DIFF
--- a/src/m_common/fortran.c
+++ b/src/m_common/fortran.c
@@ -33,7 +33,7 @@ struct complex
     double im;
 };
 #ifdef _CUBLAS
-#include <cublas.h>
+#include <cublas_v2.h>
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cudasync_(void)
@@ -80,25 +80,31 @@ void cublas_sgemm_offload_(const char * transa, const char * transb, const int *
 #ifdef _CUBLAS
 void cublas_dgemm_offload_(const char * transa, const char * transb, const int * M, const int * N, const int * K, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const double * beta, const devptr_t * devPtrC, const int * ldc)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB, devPtrC)
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
     double * devPtrC_ = (double *) devPtrC;
-    cublasDgemm(* transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
+    cublasDgemm_v2(handle, * transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_zgemm_offload_(const char * transa, const char * transb, const int * M, const int * N, const int * K, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const cuDoubleComplex * beta, const devptr_t * devPtrC, const int * ldc)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB, devPtrC)
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
     cuDoubleComplex * devPtrC_ = (cuDoubleComplex *) devPtrC;
-    cublasZgemm(* transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
+    cublasZgemm_v2(handle, * transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS

--- a/src/m_common/fortran.c
+++ b/src/m_common/fortran.c
@@ -44,37 +44,46 @@ void cudasync_(void)
 #ifdef _CUBLAS
 void cublas_dger_offload_(const int * M, const int * N, const double * alpha, const devptr_t * devPtrX, const int * incx, const devptr_t * devPtrY, const int * incy, const devptr_t * devPtrA, const int * lda)
 {
+    cublasHandle_t handle;
+    cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrX, devPtrY, devPtrA)
     {
     double * devPtrX_ = (double *) devPtrX;
     double * devPtrY_ = (double *) devPtrY;
     double * devPtrA_ = (double *) devPtrA;
-    cublasDger(* M, * N, * alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
+    cublasDger(handle, * M, * N,  alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
     }
+    cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_zgeru_offload_(const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrX, const int * incx, const devptr_t * devPtrY, const int * incy, const devptr_t * devPtrA, const int * lda)
 {
+    cublasHandle_t handle;
+    cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrX, devPtrY, devPtrA)
     {
     cuDoubleComplex * devPtrX_ = (cuDoubleComplex *) devPtrX;
     cuDoubleComplex * devPtrY_ = (cuDoubleComplex *) devPtrY;
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
-    cublasZgeru(* M, * N, * alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
+    cublasZgeru(handle, * M, * N, alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
     }
+    cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_sgemm_offload_(const char * transa, const char * transb, const int * M, const int * N, const int * K, const float * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const float * beta, const devptr_t * devPtrC, const int * ldc)
 {
+    cublasHandle_t handle;
+    cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB, devPtrC)
     {
     float * devPtrA_ = (float *) devPtrA;
     float * devPtrB_ = (float *) devPtrB;
     float * devPtrC_ = (float *) devPtrC;
-    cublasSgemm(* transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
+    cublasSgemm(handle, * transa, * transb, * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
+    cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
@@ -87,7 +96,7 @@ void cublas_dgemm_offload_(const char * transa, const char * transb, const int *
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
     double * devPtrC_ = (double *) devPtrC;
-    cublasDgemm_v2(handle, * transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
+    cublasDgemm(handle, * transa, * transb, * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
 	cublasDestroy( handle );
 }
@@ -102,7 +111,7 @@ void cublas_zgemm_offload_(const char * transa, const char * transb, const int *
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
     cuDoubleComplex * devPtrC_ = (cuDoubleComplex *) devPtrC;
-    cublasZgemm_v2(handle, * transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
+    cublasZgemm(handle, * transa, * transb, * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
 	cublasDestroy( handle );
 }
@@ -110,59 +119,74 @@ void cublas_zgemm_offload_(const char * transa, const char * transb, const int *
 #ifdef _CUBLAS
 void cublas_sgemv_offload_(const char * trans, const int * M, const int * N, const float * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const float * beta, const devptr_t * devPtrY, const int * incy)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrX, devPtrY)
     {
     float * devPtrA_ = (float *) devPtrA;
     float * devPtrX_ = (float *) devPtrX;
     float * devPtrY_ = (float *) devPtrY;
-    cublasSgemv(* trans, * M, * N, * alpha, devPtrA_, * lda, devPtrX_, * incx, * beta, devPtrY_, * incy);
+    cublasSgemv(handle, * trans, * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_dgemv_offload_(const char * trans, const int * M, const int * N, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const double * beta, const devptr_t * devPtrY, const int * incy)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrX, devPtrY)
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrX_ = (double *) devPtrX;
     double * devPtrY_ = (double *) devPtrY;
-    cublasDgemv(* trans, * M, * N, * alpha, devPtrA_, * lda, devPtrX_, * incx, * beta, devPtrY_, * incy);
+    cublasDgemv(handle, * trans, * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_zgemv_offload_(const char * trans, const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const cuDoubleComplex * beta, const devptr_t * devPtrY, const int * incy)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrX, devPtrY)
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrX_ = (cuDoubleComplex *) devPtrX;
     cuDoubleComplex * devPtrY_ = (cuDoubleComplex *) devPtrY;
-    cublasZgemv(* trans, * M, * N, * alpha, devPtrA_, * lda, devPtrX_, * incx, * beta, devPtrY_, * incy);
+    cublasZgemv(handle, * trans, * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_dtrsm_offload_(const char * side, const char * uplo, const char * transa, const char * diag, const int * M, const int * N, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB)
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
-    cublasDtrsm(* side, * uplo, * transa, * diag, * M, * N, * alpha, devPtrA_, * lda, devPtrB_, * ldb);
+    cublasDtrsm(handle, * side, * uplo, * transa, * diag, * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_ztrsm_offload_(const char * side, const char * uplo, const char * transa, const char * diag, const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB)
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
-    cublasZtrsm(* side, * uplo, * transa, * diag, * M, * N, * alpha, devPtrA_, * lda, devPtrB_, * ldb);
+    cublasZtrsm(handle, * side, * uplo, * transa, * diag, * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUSOLVER

--- a/src/m_common/fortran.c
+++ b/src/m_common/fortran.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <ctype.h>
+#include <stdio.h>
 typedef size_t devptr_t;
 struct complex
 {
@@ -50,6 +51,7 @@ cublasOperation_t cublas_op_type(const char * blas_op_type)
     if (*blas_op_type == 't') return CUBLAS_OP_T;
     if (*blas_op_type == 'C') return CUBLAS_OP_C;
     if (*blas_op_type == 'c') return CUBLAS_OP_C;
+	printf("WARNING: unrecognized blas_op_type\n");
     return -1;
 }
 cublasSideMode_t cublas_side_type(const char * blas_side_type)
@@ -58,6 +60,7 @@ cublasSideMode_t cublas_side_type(const char * blas_side_type)
     if (*blas_side_type == 'r') return CUBLAS_SIDE_RIGHT;
     if (*blas_side_type == 'L') return CUBLAS_SIDE_LEFT;
     if (*blas_side_type == 'l') return CUBLAS_SIDE_LEFT;
+	printf("WARNING: unrecognized blas_side_type\n");
     return -1;
 }
 cublasFillMode_t cublas_fill_type(const char * blas_fill_type)
@@ -66,6 +69,7 @@ cublasFillMode_t cublas_fill_type(const char * blas_fill_type)
     if (*blas_fill_type == 'u') return CUBLAS_FILL_MODE_UPPER;
     if (*blas_fill_type == 'L') return CUBLAS_FILL_MODE_LOWER;
     if (*blas_fill_type == 'l') return CUBLAS_FILL_MODE_LOWER;
+	printf("WARNING: unrecognized blas_fill_type\n");
     return -1;
 }
 cublasDiagType_t cublas_diag_type(const char * blas_diag_type)
@@ -74,6 +78,7 @@ cublasDiagType_t cublas_diag_type(const char * blas_diag_type)
     if (*blas_diag_type == 'u') return CUBLAS_DIAG_UNIT;
     if (*blas_diag_type == 'N') return CUBLAS_DIAG_NON_UNIT;
     if (*blas_diag_type == 'n') return CUBLAS_DIAG_NON_UNIT;
+	printf("WARNING: unrecognized blas_diag_type\n");
     return -1;
 }
 #endif /* _CUBLAS */

--- a/src/m_common/fortran.c
+++ b/src/m_common/fortran.c
@@ -42,6 +42,42 @@ void cudasync_(void)
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
+cublasOperation_t cublas_op_type(const char * blas_op_type)
+{
+    if (*blas_op_type == 'N') return CUBLAS_OP_N;
+    if (*blas_op_type == 'n') return CUBLAS_OP_N;
+    if (*blas_op_type == 'T') return CUBLAS_OP_T;
+    if (*blas_op_type == 't') return CUBLAS_OP_T;
+    if (*blas_op_type == 'C') return CUBLAS_OP_C;
+    if (*blas_op_type == 'c') return CUBLAS_OP_C;
+    return -1;
+}
+cublasSideMode_t cublas_side_type(const char * blas_side_type)
+{
+    if (*blas_side_type == 'R') return CUBLAS_SIDE_RIGHT;
+    if (*blas_side_type == 'r') return CUBLAS_SIDE_RIGHT;
+    if (*blas_side_type == 'L') return CUBLAS_SIDE_LEFT;
+    if (*blas_side_type == 'l') return CUBLAS_SIDE_LEFT;
+    return -1;
+}
+cublasFillMode_t cublas_fill_type(const char * blas_fill_type)
+{
+    if (*blas_fill_type == 'U') return CUBLAS_FILL_MODE_UPPER;
+    if (*blas_fill_type == 'u') return CUBLAS_FILL_MODE_UPPER;
+    if (*blas_fill_type == 'L') return CUBLAS_FILL_MODE_LOWER;
+    if (*blas_fill_type == 'l') return CUBLAS_FILL_MODE_LOWER;
+    return -1;
+}
+cublasDiagType_t cublas_diag_type(const char * blas_diag_type)
+{
+    if (*blas_diag_type == 'U') return CUBLAS_DIAG_UNIT;
+    if (*blas_diag_type == 'u') return CUBLAS_DIAG_UNIT;
+    if (*blas_diag_type == 'N') return CUBLAS_DIAG_NON_UNIT;
+    if (*blas_diag_type == 'n') return CUBLAS_DIAG_NON_UNIT;
+    return -1;
+}
+#endif /* _CUBLAS */
+#ifdef _CUBLAS
 void cublas_dger_offload_(const int * M, const int * N, const double * alpha, const devptr_t * devPtrX, const int * incx, const devptr_t * devPtrY, const int * incy, const devptr_t * devPtrA, const int * lda)
 {
     cublasHandle_t handle;
@@ -81,7 +117,7 @@ void cublas_sgemm_offload_(const char * transa, const char * transb, const int *
     float * devPtrA_ = (float *) devPtrA;
     float * devPtrB_ = (float *) devPtrB;
     float * devPtrC_ = (float *) devPtrC;
-    cublasSgemm(handle, * transa, * transb, * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
+    cublasSgemm(handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
     cublasDestroy( handle );
 }
@@ -96,7 +132,7 @@ void cublas_dgemm_offload_(const char * transa, const char * transb, const int *
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
     double * devPtrC_ = (double *) devPtrC;
-    cublasDgemm(handle, * transa, * transb, * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
+    cublasDgemm(handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
 	cublasDestroy( handle );
 }
@@ -111,7 +147,7 @@ void cublas_zgemm_offload_(const char * transa, const char * transb, const int *
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
     cuDoubleComplex * devPtrC_ = (cuDoubleComplex *) devPtrC;
-    cublasZgemm(handle, * transa, * transb, * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
+    cublasZgemm(handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
 	cublasDestroy( handle );
 }
@@ -126,7 +162,7 @@ void cublas_sgemv_offload_(const char * trans, const int * M, const int * N, con
     float * devPtrA_ = (float *) devPtrA;
     float * devPtrX_ = (float *) devPtrX;
     float * devPtrY_ = (float *) devPtrY;
-    cublasSgemv(handle, * trans, * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
+    cublasSgemv(handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
 	cublasDestroy( handle );
 }
@@ -141,7 +177,7 @@ void cublas_dgemv_offload_(const char * trans, const int * M, const int * N, con
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrX_ = (double *) devPtrX;
     double * devPtrY_ = (double *) devPtrY;
-    cublasDgemv(handle, * trans, * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
+    cublasDgemv(handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
 	cublasDestroy( handle );
 }
@@ -156,7 +192,7 @@ void cublas_zgemv_offload_(const char * trans, const int * M, const int * N, con
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrX_ = (cuDoubleComplex *) devPtrX;
     cuDoubleComplex * devPtrY_ = (cuDoubleComplex *) devPtrY;
-    cublasZgemv(handle, * trans, * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
+    cublasZgemv(handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
 	cublasDestroy( handle );
 }
@@ -170,7 +206,7 @@ void cublas_dtrsm_offload_(const char * side, const char * uplo, const char * tr
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
-    cublasDtrsm(handle, * side, * uplo, * transa, * diag, * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
+    cublasDtrsm(handle, cublas_side_type(side), cublas_fill_type(uplo), cublas_op_type(transa), cublas_diag_type(diag), * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
     }
 	cublasDestroy( handle );
 }
@@ -184,7 +220,7 @@ void cublas_ztrsm_offload_(const char * side, const char * uplo, const char * tr
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
-    cublasZtrsm(handle, * side, * uplo, * transa, * diag, * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
+    cublasZtrsm(handle, cublas_side_type(side), cublas_fill_type(uplo), cublas_op_type(transa), cublas_diag_type(diag), * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
     }
 	cublasDestroy( handle );
 }


### PR DESCRIPTION
From cuda12 on the `cublas.h` header conflicts with `cusolverDn.h`, which imports `cublas_v2.h` instead.
- Updated `m_common/fortran.c` to comply with the `cublas_v2.h` API.
- Tested with nvhpc/23.11 and nvhpc/24.3 on LeonardoBooster@CINECA, all tests pass. 