### PR TITLE
Upgraded cublas interface

### DIFF
--- a/src/a_module_tests/test_dgemm.f90
+++ b/src/a_module_tests/test_dgemm.f90
@@ -60,6 +60,14 @@ program test_dgemm
     C = 0
 
 #if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+        call cublas_handle_init_()
+#else
+        call cublas_handle_init()
+#endif
+#endif
+
+#if defined(_OFFLOAD) && defined(_CUBLAS)
 !$omp target data map(to:A,B)
 !$omp target data map(from:C)
 #endif

--- a/src/a_module_tests/test_dgemm_b.f90
+++ b/src/a_module_tests/test_dgemm_b.f90
@@ -80,6 +80,14 @@ program test_dgemm_b
     CB_i = CB
 
 #if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+        call cublas_handle_init_()
+#else
+        call cublas_handle_init()
+#endif
+#endif
+
+#if defined(_OFFLOAD) && defined(_CUBLAS)
 !$omp target data map(to:A,B)
 !$omp target data map(tofrom:AB,BB,CB)
 #endif

--- a/src/a_module_tests/test_dger.f90
+++ b/src/a_module_tests/test_dger.f90
@@ -31,6 +31,14 @@ program test_dger
     yes_ontarget = .true.
 #endif
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     read (*, *) s
 
     allocate (A(s, s))

--- a/src/a_module_tests/test_dger2.f90
+++ b/src/a_module_tests/test_dger2.f90
@@ -31,6 +31,14 @@ program test_dger2
     yes_ontarget = .true.
 #endif
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     read (*, *) s
 
     allocate (A(s, s))

--- a/src/a_module_tests/test_dtrsm.f90
+++ b/src/a_module_tests/test_dtrsm.f90
@@ -21,6 +21,14 @@ program test_dtrsm
     integer :: s, gen, ii, jj
     character(len=1) :: uplo, side, trans
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     ! gen = 1 : Generate matrices
     ! gen = 0 : Compare matrices
 

--- a/src/a_module_tests/test_zgemm.f90
+++ b/src/a_module_tests/test_zgemm.f90
@@ -25,6 +25,14 @@ program test_zgemm
     character(len=1) :: first, second
     character(len=100) :: message, str_tmp1, str_tmp2
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     ! gen = 1 : Generate matrices
     ! gen = 0 : Compare matrices
 

--- a/src/a_module_tests/test_zgemm_b.f90
+++ b/src/a_module_tests/test_zgemm_b.f90
@@ -26,6 +26,14 @@ program test_zgemm_b
     character(len=1) :: first, second
     character(len=100) :: message, str_tmp1, str_tmp2
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     ! gen = 1 : Generate matrices
     ! gen = 0 : Compare matrices
 

--- a/src/a_module_tests/test_zgemv.f90
+++ b/src/a_module_tests/test_zgemv.f90
@@ -30,6 +30,14 @@ program test_zgemv
     yes_on_target = .true.
 #endif
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     ! gen = 1 : Generate matrices
     ! gen = 0 : Compare matrices
 

--- a/src/a_module_tests/test_zgemv_offload.f90
+++ b/src/a_module_tests/test_zgemv_offload.f90
@@ -23,6 +23,14 @@ program test_zgemvn_offload
     character(len=1) :: operation
     integer :: s, gen
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     ! gen = 1 : Generate matrices
     ! gen = 0 : Compare matrices
 

--- a/src/a_module_tests/test_zger.f90
+++ b/src/a_module_tests/test_zger.f90
@@ -27,6 +27,14 @@ program test_zgeru
     real*8 :: one = 1.d0, zero = 0.d0
     integer :: s, ii, jj
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     read (*, *) s
 
     allocate (A(s, s))

--- a/src/a_module_tests/test_zger2.f90
+++ b/src/a_module_tests/test_zger2.f90
@@ -31,6 +31,14 @@ program test_zger2
     yes_ontarget = .true.
 #endif
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     read (*, *) s
 
     allocate (A(s, s))

--- a/src/a_module_tests/test_zgeru.f90
+++ b/src/a_module_tests/test_zgeru.f90
@@ -31,6 +31,14 @@ program test_zgeru
     yes_ontarget = .true.
 #endif
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     read (*, *) s
 
     allocate (A(s, s))

--- a/src/a_module_tests/test_ztrsm.f90
+++ b/src/a_module_tests/test_ztrsm.f90
@@ -22,6 +22,14 @@ program test_ztrsm
     integer :: s, gen, ii, jj
     character(len=1) :: uplo, side, trans
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     ! gen = 1 : Generate matrices
     ! gen = 0 : Compare matrices
 

--- a/src/a_prep/prep.f90
+++ b/src/a_prep/prep.f90
@@ -109,6 +109,13 @@ program main
     ! 4) generate scratch files for continuation.
     call Initializeall
     !
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+        call cublas_handle_init_()
+#else
+        call cublas_handle_init()
+#endif
+#endif
     ! deallocate useless variables allocated for QMC
     ! small reallocation just to be safe
     !

--- a/src/a_readforward/readforward.f90
+++ b/src/a_readforward/readforward.f90
@@ -592,6 +592,15 @@ program readforward
 #endif
 
     end if
+
+#ifdef _CUBLAS
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
 #ifdef _CUSOLVER
 #ifdef RISC
     call cusolver_handle_init_(handle)

--- a/src/a_turborvb/main.f90
+++ b/src/a_turborvb/main.f90
@@ -5489,6 +5489,14 @@ contains
         yesmin_read = .false.
         if (molopt .ne. 0) yesmin_read = .true.
 
+#ifdef _CUBLAS
+#ifdef RISC
+        call cublas_handle_init_()
+#else
+        call cublas_handle_init()
+#endif
+#endif
+
 #ifdef _CUSOLVER
 #ifdef RISC
         call cusolver_handle_init_(handle)
@@ -8729,6 +8737,14 @@ contains
         iend_sav = iend
 
         iend = i_main
+
+#ifdef _CUBLAS
+#ifdef RISC
+        call cublas_handle_destroy_()
+#else
+        call cublas_handle_destroy()
+#endif
+#endif
 
 #ifdef _CUSOLVER
 #ifdef RISC

--- a/src/m_common/fortran.c
+++ b/src/m_common/fortran.c
@@ -33,7 +33,7 @@ struct complex
     double im;
 };
 #ifdef _CUBLAS
-#include <cublas.h>
+#include <cublas_v2.h>
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cudasync_(void)
@@ -80,25 +80,31 @@ void cublas_sgemm_offload_(const char * transa, const char * transb, const int *
 #ifdef _CUBLAS
 void cublas_dgemm_offload_(const char * transa, const char * transb, const int * M, const int * N, const int * K, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const double * beta, const devptr_t * devPtrC, const int * ldc)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB, devPtrC)
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
     double * devPtrC_ = (double *) devPtrC;
-    cublasDgemm(* transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
+    cublasDgemm_v2(handle, * transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_zgemm_offload_(const char * transa, const char * transb, const int * M, const int * N, const int * K, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const cuDoubleComplex * beta, const devptr_t * devPtrC, const int * ldc)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB, devPtrC)
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
     cuDoubleComplex * devPtrC_ = (cuDoubleComplex *) devPtrC;
-    cublasZgemm(* transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
+    cublasZgemm_v2(handle, * transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS

--- a/src/m_common/fortran.c
+++ b/src/m_common/fortran.c
@@ -44,37 +44,46 @@ void cudasync_(void)
 #ifdef _CUBLAS
 void cublas_dger_offload_(const int * M, const int * N, const double * alpha, const devptr_t * devPtrX, const int * incx, const devptr_t * devPtrY, const int * incy, const devptr_t * devPtrA, const int * lda)
 {
+    cublasHandle_t handle;
+    cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrX, devPtrY, devPtrA)
     {
     double * devPtrX_ = (double *) devPtrX;
     double * devPtrY_ = (double *) devPtrY;
     double * devPtrA_ = (double *) devPtrA;
-    cublasDger(* M, * N, * alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
+    cublasDger(handle, * M, * N,  alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
     }
+    cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_zgeru_offload_(const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrX, const int * incx, const devptr_t * devPtrY, const int * incy, const devptr_t * devPtrA, const int * lda)
 {
+    cublasHandle_t handle;
+    cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrX, devPtrY, devPtrA)
     {
     cuDoubleComplex * devPtrX_ = (cuDoubleComplex *) devPtrX;
     cuDoubleComplex * devPtrY_ = (cuDoubleComplex *) devPtrY;
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
-    cublasZgeru(* M, * N, * alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
+    cublasZgeru(handle, * M, * N, alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
     }
+    cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_sgemm_offload_(const char * transa, const char * transb, const int * M, const int * N, const int * K, const float * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const float * beta, const devptr_t * devPtrC, const int * ldc)
 {
+    cublasHandle_t handle;
+    cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB, devPtrC)
     {
     float * devPtrA_ = (float *) devPtrA;
     float * devPtrB_ = (float *) devPtrB;
     float * devPtrC_ = (float *) devPtrC;
-    cublasSgemm(* transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
+    cublasSgemm(handle, * transa, * transb, * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
+    cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
@@ -87,7 +96,7 @@ void cublas_dgemm_offload_(const char * transa, const char * transb, const int *
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
     double * devPtrC_ = (double *) devPtrC;
-    cublasDgemm_v2(handle, * transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
+    cublasDgemm(handle, * transa, * transb, * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
 	cublasDestroy( handle );
 }
@@ -102,7 +111,7 @@ void cublas_zgemm_offload_(const char * transa, const char * transb, const int *
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
     cuDoubleComplex * devPtrC_ = (cuDoubleComplex *) devPtrC;
-    cublasZgemm_v2(handle, * transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
+    cublasZgemm(handle, * transa, * transb, * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
 	cublasDestroy( handle );
 }
@@ -110,59 +119,74 @@ void cublas_zgemm_offload_(const char * transa, const char * transb, const int *
 #ifdef _CUBLAS
 void cublas_sgemv_offload_(const char * trans, const int * M, const int * N, const float * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const float * beta, const devptr_t * devPtrY, const int * incy)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrX, devPtrY)
     {
     float * devPtrA_ = (float *) devPtrA;
     float * devPtrX_ = (float *) devPtrX;
     float * devPtrY_ = (float *) devPtrY;
-    cublasSgemv(* trans, * M, * N, * alpha, devPtrA_, * lda, devPtrX_, * incx, * beta, devPtrY_, * incy);
+    cublasSgemv(handle, * trans, * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_dgemv_offload_(const char * trans, const int * M, const int * N, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const double * beta, const devptr_t * devPtrY, const int * incy)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrX, devPtrY)
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrX_ = (double *) devPtrX;
     double * devPtrY_ = (double *) devPtrY;
-    cublasDgemv(* trans, * M, * N, * alpha, devPtrA_, * lda, devPtrX_, * incx, * beta, devPtrY_, * incy);
+    cublasDgemv(handle, * trans, * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_zgemv_offload_(const char * trans, const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const cuDoubleComplex * beta, const devptr_t * devPtrY, const int * incy)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrX, devPtrY)
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrX_ = (cuDoubleComplex *) devPtrX;
     cuDoubleComplex * devPtrY_ = (cuDoubleComplex *) devPtrY;
-    cublasZgemv(* trans, * M, * N, * alpha, devPtrA_, * lda, devPtrX_, * incx, * beta, devPtrY_, * incy);
+    cublasZgemv(handle, * trans, * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_dtrsm_offload_(const char * side, const char * uplo, const char * transa, const char * diag, const int * M, const int * N, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB)
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
-    cublasDtrsm(* side, * uplo, * transa, * diag, * M, * N, * alpha, devPtrA_, * lda, devPtrB_, * ldb);
+    cublasDtrsm(handle, * side, * uplo, * transa, * diag, * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_ztrsm_offload_(const char * side, const char * uplo, const char * transa, const char * diag, const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB)
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
-    cublasZtrsm(* side, * uplo, * transa, * diag, * M, * N, * alpha, devPtrA_, * lda, devPtrB_, * ldb);
+    cublasZtrsm(handle, * side, * uplo, * transa, * diag, * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUSOLVER

--- a/src/m_common/fortran.c
+++ b/src/m_common/fortran.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <ctype.h>
+#include <stdio.h>
 typedef size_t devptr_t;
 struct complex
 {
@@ -50,6 +51,7 @@ cublasOperation_t cublas_op_type(const char * blas_op_type)
     if (*blas_op_type == 't') return CUBLAS_OP_T;
     if (*blas_op_type == 'C') return CUBLAS_OP_C;
     if (*blas_op_type == 'c') return CUBLAS_OP_C;
+	printf("WARNING: unrecognized blas_op_type\n");
     return -1;
 }
 cublasSideMode_t cublas_side_type(const char * blas_side_type)
@@ -58,6 +60,7 @@ cublasSideMode_t cublas_side_type(const char * blas_side_type)
     if (*blas_side_type == 'r') return CUBLAS_SIDE_RIGHT;
     if (*blas_side_type == 'L') return CUBLAS_SIDE_LEFT;
     if (*blas_side_type == 'l') return CUBLAS_SIDE_LEFT;
+	printf("WARNING: unrecognized blas_side_type\n");
     return -1;
 }
 cublasFillMode_t cublas_fill_type(const char * blas_fill_type)
@@ -66,6 +69,7 @@ cublasFillMode_t cublas_fill_type(const char * blas_fill_type)
     if (*blas_fill_type == 'u') return CUBLAS_FILL_MODE_UPPER;
     if (*blas_fill_type == 'L') return CUBLAS_FILL_MODE_LOWER;
     if (*blas_fill_type == 'l') return CUBLAS_FILL_MODE_LOWER;
+	printf("WARNING: unrecognized blas_fill_type\n");
     return -1;
 }
 cublasDiagType_t cublas_diag_type(const char * blas_diag_type)
@@ -74,6 +78,7 @@ cublasDiagType_t cublas_diag_type(const char * blas_diag_type)
     if (*blas_diag_type == 'u') return CUBLAS_DIAG_UNIT;
     if (*blas_diag_type == 'N') return CUBLAS_DIAG_NON_UNIT;
     if (*blas_diag_type == 'n') return CUBLAS_DIAG_NON_UNIT;
+	printf("WARNING: unrecognized blas_diag_type\n");
     return -1;
 }
 #endif /* _CUBLAS */

--- a/src/m_common/fortran.c
+++ b/src/m_common/fortran.c
@@ -35,6 +35,17 @@ struct complex
 };
 #ifdef _CUBLAS
 #include <cublas_v2.h>
+cublasHandle_t cublas_handle;
+#endif /* _CUBLAS */
+#ifdef _CUBLAS
+void cublas_handle_init_()
+{
+	cublasCreate(&cublas_handle);
+}
+void cublas_handle_destroy_()
+{
+    cublasDestroy(cublas_handle);
+}
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cudasync_(void)
@@ -85,149 +96,119 @@ cublasDiagType_t cublas_diag_type(const char * blas_diag_type)
 #ifdef _CUBLAS
 void cublas_dger_offload_(const int * M, const int * N, const double * alpha, const devptr_t * devPtrX, const int * incx, const devptr_t * devPtrY, const int * incy, const devptr_t * devPtrA, const int * lda)
 {
-    cublasHandle_t handle;
-    cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrX, devPtrY, devPtrA)
     {
     double * devPtrX_ = (double *) devPtrX;
     double * devPtrY_ = (double *) devPtrY;
     double * devPtrA_ = (double *) devPtrA;
-    cublasDger(handle, * M, * N,  alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
+    cublasDger(cublas_handle, * M, * N,  alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
     }
-    cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_zgeru_offload_(const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrX, const int * incx, const devptr_t * devPtrY, const int * incy, const devptr_t * devPtrA, const int * lda)
 {
-    cublasHandle_t handle;
-    cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrX, devPtrY, devPtrA)
     {
     cuDoubleComplex * devPtrX_ = (cuDoubleComplex *) devPtrX;
     cuDoubleComplex * devPtrY_ = (cuDoubleComplex *) devPtrY;
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
-    cublasZgeru(handle, * M, * N, alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
+    cublasZgeru(cublas_handle, * M, * N, alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
     }
-    cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_sgemm_offload_(const char * transa, const char * transb, const int * M, const int * N, const int * K, const float * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const float * beta, const devptr_t * devPtrC, const int * ldc)
 {
-    cublasHandle_t handle;
-    cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB, devPtrC)
     {
     float * devPtrA_ = (float *) devPtrA;
     float * devPtrB_ = (float *) devPtrB;
     float * devPtrC_ = (float *) devPtrC;
-    cublasSgemm(handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
+    cublasSgemm(cublas_handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
-    cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_dgemm_offload_(const char * transa, const char * transb, const int * M, const int * N, const int * K, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const double * beta, const devptr_t * devPtrC, const int * ldc)
 {
-	cublasHandle_t handle;
-	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB, devPtrC)
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
     double * devPtrC_ = (double *) devPtrC;
-    cublasDgemm(handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
+    cublasDgemm(cublas_handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
-	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_zgemm_offload_(const char * transa, const char * transb, const int * M, const int * N, const int * K, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const cuDoubleComplex * beta, const devptr_t * devPtrC, const int * ldc)
 {
-	cublasHandle_t handle;
-	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB, devPtrC)
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
     cuDoubleComplex * devPtrC_ = (cuDoubleComplex *) devPtrC;
-    cublasZgemm(handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
+    cublasZgemm(cublas_handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
-	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_sgemv_offload_(const char * trans, const int * M, const int * N, const float * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const float * beta, const devptr_t * devPtrY, const int * incy)
 {
-	cublasHandle_t handle;
-	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrX, devPtrY)
     {
     float * devPtrA_ = (float *) devPtrA;
     float * devPtrX_ = (float *) devPtrX;
     float * devPtrY_ = (float *) devPtrY;
-    cublasSgemv(handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
+    cublasSgemv(cublas_handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
-	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_dgemv_offload_(const char * trans, const int * M, const int * N, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const double * beta, const devptr_t * devPtrY, const int * incy)
 {
-	cublasHandle_t handle;
-	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrX, devPtrY)
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrX_ = (double *) devPtrX;
     double * devPtrY_ = (double *) devPtrY;
-    cublasDgemv(handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
+    cublasDgemv(cublas_handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
-	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_zgemv_offload_(const char * trans, const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const cuDoubleComplex * beta, const devptr_t * devPtrY, const int * incy)
 {
-	cublasHandle_t handle;
-	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrX, devPtrY)
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrX_ = (cuDoubleComplex *) devPtrX;
     cuDoubleComplex * devPtrY_ = (cuDoubleComplex *) devPtrY;
-    cublasZgemv(handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
+    cublasZgemv(cublas_handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
-	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_dtrsm_offload_(const char * side, const char * uplo, const char * transa, const char * diag, const int * M, const int * N, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb)
 {
-	cublasHandle_t handle;
-	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB)
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
-    cublasDtrsm(handle, cublas_side_type(side), cublas_fill_type(uplo), cublas_op_type(transa), cublas_diag_type(diag), * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
+    cublasDtrsm(cublas_handle, cublas_side_type(side), cublas_fill_type(uplo), cublas_op_type(transa), cublas_diag_type(diag), * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
     }
-	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_ztrsm_offload_(const char * side, const char * uplo, const char * transa, const char * diag, const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb)
 {
-	cublasHandle_t handle;
-	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB)
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
-    cublasZtrsm(handle, cublas_side_type(side), cublas_fill_type(uplo), cublas_op_type(transa), cublas_diag_type(diag), * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
+    cublasZtrsm(cublas_handle, cublas_side_type(side), cublas_fill_type(uplo), cublas_op_type(transa), cublas_diag_type(diag), * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
     }
-	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUSOLVER

--- a/src/m_common/fortran.c
+++ b/src/m_common/fortran.c
@@ -42,6 +42,42 @@ void cudasync_(void)
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
+cublasOperation_t cublas_op_type(const char * blas_op_type)
+{
+    if (*blas_op_type == 'N') return CUBLAS_OP_N;
+    if (*blas_op_type == 'n') return CUBLAS_OP_N;
+    if (*blas_op_type == 'T') return CUBLAS_OP_T;
+    if (*blas_op_type == 't') return CUBLAS_OP_T;
+    if (*blas_op_type == 'C') return CUBLAS_OP_C;
+    if (*blas_op_type == 'c') return CUBLAS_OP_C;
+    return -1;
+}
+cublasSideMode_t cublas_side_type(const char * blas_side_type)
+{
+    if (*blas_side_type == 'R') return CUBLAS_SIDE_RIGHT;
+    if (*blas_side_type == 'r') return CUBLAS_SIDE_RIGHT;
+    if (*blas_side_type == 'L') return CUBLAS_SIDE_LEFT;
+    if (*blas_side_type == 'l') return CUBLAS_SIDE_LEFT;
+    return -1;
+}
+cublasFillMode_t cublas_fill_type(const char * blas_fill_type)
+{
+    if (*blas_fill_type == 'U') return CUBLAS_FILL_MODE_UPPER;
+    if (*blas_fill_type == 'u') return CUBLAS_FILL_MODE_UPPER;
+    if (*blas_fill_type == 'L') return CUBLAS_FILL_MODE_LOWER;
+    if (*blas_fill_type == 'l') return CUBLAS_FILL_MODE_LOWER;
+    return -1;
+}
+cublasDiagType_t cublas_diag_type(const char * blas_diag_type)
+{
+    if (*blas_diag_type == 'U') return CUBLAS_DIAG_UNIT;
+    if (*blas_diag_type == 'u') return CUBLAS_DIAG_UNIT;
+    if (*blas_diag_type == 'N') return CUBLAS_DIAG_NON_UNIT;
+    if (*blas_diag_type == 'n') return CUBLAS_DIAG_NON_UNIT;
+    return -1;
+}
+#endif /* _CUBLAS */
+#ifdef _CUBLAS
 void cublas_dger_offload_(const int * M, const int * N, const double * alpha, const devptr_t * devPtrX, const int * incx, const devptr_t * devPtrY, const int * incy, const devptr_t * devPtrA, const int * lda)
 {
     cublasHandle_t handle;
@@ -81,7 +117,7 @@ void cublas_sgemm_offload_(const char * transa, const char * transb, const int *
     float * devPtrA_ = (float *) devPtrA;
     float * devPtrB_ = (float *) devPtrB;
     float * devPtrC_ = (float *) devPtrC;
-    cublasSgemm(handle, * transa, * transb, * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
+    cublasSgemm(handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
     cublasDestroy( handle );
 }
@@ -96,7 +132,7 @@ void cublas_dgemm_offload_(const char * transa, const char * transb, const int *
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
     double * devPtrC_ = (double *) devPtrC;
-    cublasDgemm(handle, * transa, * transb, * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
+    cublasDgemm(handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
 	cublasDestroy( handle );
 }
@@ -111,7 +147,7 @@ void cublas_zgemm_offload_(const char * transa, const char * transb, const int *
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
     cuDoubleComplex * devPtrC_ = (cuDoubleComplex *) devPtrC;
-    cublasZgemm(handle, * transa, * transb, * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
+    cublasZgemm(handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
 	cublasDestroy( handle );
 }
@@ -126,7 +162,7 @@ void cublas_sgemv_offload_(const char * trans, const int * M, const int * N, con
     float * devPtrA_ = (float *) devPtrA;
     float * devPtrX_ = (float *) devPtrX;
     float * devPtrY_ = (float *) devPtrY;
-    cublasSgemv(handle, * trans, * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
+    cublasSgemv(handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
 	cublasDestroy( handle );
 }
@@ -141,7 +177,7 @@ void cublas_dgemv_offload_(const char * trans, const int * M, const int * N, con
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrX_ = (double *) devPtrX;
     double * devPtrY_ = (double *) devPtrY;
-    cublasDgemv(handle, * trans, * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
+    cublasDgemv(handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
 	cublasDestroy( handle );
 }
@@ -156,7 +192,7 @@ void cublas_zgemv_offload_(const char * trans, const int * M, const int * N, con
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrX_ = (cuDoubleComplex *) devPtrX;
     cuDoubleComplex * devPtrY_ = (cuDoubleComplex *) devPtrY;
-    cublasZgemv(handle, * trans, * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
+    cublasZgemv(handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
 	cublasDestroy( handle );
 }
@@ -170,7 +206,7 @@ void cublas_dtrsm_offload_(const char * side, const char * uplo, const char * tr
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
-    cublasDtrsm(handle, * side, * uplo, * transa, * diag, * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
+    cublasDtrsm(handle, cublas_side_type(side), cublas_fill_type(uplo), cublas_op_type(transa), cublas_diag_type(diag), * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
     }
 	cublasDestroy( handle );
 }
@@ -184,7 +220,7 @@ void cublas_ztrsm_offload_(const char * side, const char * uplo, const char * tr
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
-    cublasZtrsm(handle, * side, * uplo, * transa, * diag, * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
+    cublasZtrsm(handle, cublas_side_type(side), cublas_fill_type(uplo), cublas_op_type(transa), cublas_diag_type(diag), * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
     }
 	cublasDestroy( handle );
 }


### PR DESCRIPTION
- Upgraded cublas library C interface with a `handle` parameter, solving conflicts with latest cusolver versions and enabling the compilation with nvhpc > 23.1. 
- A global `cublas_handle` variable is initialized by each MPI process and used by all its cublas calls. Care needed if cublas are called inside a multi-threaded region (does not seem to be the case).